### PR TITLE
USB-DAC Volume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Features:
  - Tune volume on speed (steps: 60, 100, 120 km/h)
  - Background volume change (no stock or system UI)
  - Safe volume level set on start/stop headunit
+ - Supports volume adjusting on a USB-DAC synchronously (Alsamixer and Root required)
 
 Supports head units on Rockchip RK30SDK platform: RK3066 (Android 4.2.2 and 4.4.X)
  - Klyde (KLD)

--- a/app/src/main/java/com/petrows/mtcservice/SWCReceiver.java
+++ b/app/src/main/java/com/petrows/mtcservice/SWCReceiver.java
@@ -47,6 +47,24 @@ public class SWCReceiver extends BroadcastReceiver {
 		                Settings.get(context).startMediaPlayer();
 	                }
                 }
+				if (Settings.MTCKeysVolumeUp.contains(keyCode)){
+					int vol = Settings.get(context).getVolume();
+					int volNew = vol + 1;
+					Settings.get(context).setVolumeUSB(volNew);
+				}
+				if (Settings.MTCKeysVolumeDown.contains(keyCode)){
+					int vol = Settings.get(context).getVolume();
+					int volNew = vol - 1;
+					Settings.get(context).setVolumeUSB(volNew);
+				}
+				if (Settings.MTCKeysPrevInCat.contains(keyCode)) {
+					Settings.get(context).showToast("<< in cat");
+					ControllerList.get(context).sendKeyPrevInCat();
+				}
+				if (Settings.MTCKeysNextInCat.contains(keyCode)) {
+					Settings.get(context).showToast(">> in cat");
+					ControllerList.get(context).sendKeyNextInCat();
+				}
 			} else {
 				Log.d(TAG, "Media keys handler is disabled in settings");
 			}

--- a/app/src/main/java/com/petrows/mtcservice/Settings.java
+++ b/app/src/main/java/com/petrows/mtcservice/Settings.java
@@ -36,13 +36,18 @@ public class Settings {
 	//final static String MTCBroadcastIrkeyDown = "com.microntek.irkeyDown";
 	final static String MTCBroadcastACC = "com.microntek.acc";
 
-	final static List<Integer> MTCKeysPrev = Arrays.asList(45, 58, 22);
-	final static List<Integer> MTCKeysNext = Arrays.asList(46, 59, 24);
+	final static List<Integer> MTCKeysPrev = Arrays.asList(45, 58, 22, 63);
+	final static List<Integer> MTCKeysNext = Arrays.asList(46, 59, 24, 64);
 	final static List<Integer> MTCKeysPause = Arrays.asList(3);
     final static List<Integer> MTCKeysPhone = Arrays.asList(69);
 	final static List<String> MTCMusicApps = Arrays.asList(
 			"com.microntek.radio.RadioActivity", "com.microntek.music.MusicActivity", "com.microntek.dvd.DVDActivity", "com.microntek.ipod.IPODActivity", "com.microntek.media.MediaActivity", "com.microntek.bluetooth.BlueToothActivity"
 	);
+
+	final static List<Integer> MTCKeysVolumeUp = Arrays.asList(19);
+	final static List<Integer> MTCKeysVolumeDown = Arrays.asList(27);
+	final static List<Integer> MTCKeysPrevInCat = Arrays.asList(61);
+	final static List<Integer> MTCKeysNextInCat = Arrays.asList(62);
 
 
 	final static String MTCBroadcastWidget = "com.android.MTClauncher.action.INSTALL_WIDGETS";
@@ -345,6 +350,18 @@ public class Settings {
 		return Integer.valueOf(prefs.getString("speed.speedvol", "5"));
 	}
 
+	public boolean getUSBenable() {
+		return prefs.getBoolean("usbvol.enable", false);
+	}
+
+	public String USBnumber() {
+		return prefs.getString("usbvol.number", "2");
+	}
+
+	public String USBname() {
+		return prefs.getString("usbvol.name", "PCM");
+	}
+
 	public List<Integer> getSpeedValues() {
 		// Load speed values
 		if (speedValues == null || speedValues.size() <= 0) {
@@ -406,6 +423,25 @@ public class Settings {
 		android.provider.Settings.System.putInt(ctx.getContentResolver(),
 				"av_volume=", level);
 		am.setParameters("av_volume=" + mtcGetRealVolume(level));
+	
+		setVolumeUSB_alsa(level);
+	}
+
+	public void setVolumeUSB_alsa(int level) {
+		//Need app AlsaMixer and ROOT
+		if (getUSBenable()) {
+			Log.d(TAG, "Settings new volume USB: " + level + ", real: " + mtcGetRealVolume(level) + "%");
+			RootSession.get(ctx).exec("alsa_amixer -c" + USBnumber() + " sset '" + USBname() + "' " + mtcGetRealVolume(level) + "%");
+		}
+	}
+
+	public void setVolumeUSB(int level) {
+		if (level < 0 || level > (int) volumeMax) {
+			Log.w(TAG, "Volume USB level " + level + " is wrong, ignore it");
+			return;
+		}
+
+		setVolumeUSB_alsa(level);
 	}
 
 	public void setVolumeSafe() {

--- a/app/src/main/java/com/petrows/mtcservice/appcontrol/ControllerBase.java
+++ b/app/src/main/java/com/petrows/mtcservice/appcontrol/ControllerBase.java
@@ -58,4 +58,15 @@ public abstract class ControllerBase {
 	public boolean onPlayPause() {
 		return false;
 	}
+	
+	// Play NEXT/IN CAT
+	public boolean onNextInCat() {
+		return false;
+	}
+
+	// Play PREV/IN CAT
+	public boolean onPrevInCat() {
+		return false;
+	}
+	
 }

--- a/app/src/main/java/com/petrows/mtcservice/appcontrol/ControllerList.java
+++ b/app/src/main/java/com/petrows/mtcservice/appcontrol/ControllerList.java
@@ -149,4 +149,36 @@ public class ControllerList {
 		}
 		return false; // No app!
 	}
+
+	public boolean sendKeyNextInCat()
+	{
+		ArrayList<ControllerBase> apps = getListCall();
+		for (ControllerBase app : apps)
+		{
+			Log.d(TAG, "Probe NEXT IN CAT : " + app.getId());
+			if (app.onNextInCat())
+			{
+				// Key is sended!
+				Log.d(TAG, "Sended");
+				return true;
+			}
+		}
+		return false; // No app!
+	}
+
+	public boolean sendKeyPrevInCat()
+	{
+		ArrayList<ControllerBase> apps = getListCall();
+		for (ControllerBase app : apps)
+		{
+			Log.d(TAG, "Probe PREV IN CAT : " + app.getId());
+			if (app.onPrevInCat())
+			{
+				// Key is sended!
+				Log.d(TAG, "Sended");
+				return true;
+			}
+		}
+		return false; // No app!
+	}
 }

--- a/app/src/main/java/com/petrows/mtcservice/appcontrol/ControllerPowerAmp.java
+++ b/app/src/main/java/com/petrows/mtcservice/appcontrol/ControllerPowerAmp.java
@@ -70,4 +70,21 @@ public class ControllerPowerAmp extends ControllerBase {
 		ctx.startService(control);
 		return true;
 	}
+	@Override
+	public boolean onNextInCat() {
+		if (!isRunning()) return false; // No app - no key
+		Intent control = PowerampAPI.newAPIIntent();
+		control.putExtra(PowerampAPI.COMMAND, PowerampAPI.Commands.NEXT_IN_CAT);
+		ctx.startService(control);
+		return true;
+	}
+
+	@Override
+	public boolean onPrevInCat() {
+		if (!isRunning()) return false; // No app - no key
+		Intent control = PowerampAPI.newAPIIntent();
+		control.putExtra(PowerampAPI.COMMAND, PowerampAPI.Commands.PREVIOUS_IN_CAT);
+		ctx.startService(control);
+		return true;
+	}
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -48,6 +48,13 @@
     <string name="ui_adv_settings_svol_enable_text">Setze eine sichere Lautstärke beim Start des Geräts</string>
     <string name="ui_adv_settings_svol_enable_title">Aktivieren beim Start</string>
     <string name="ui_adv_settings_svol_level_text">Setzen der sicheren Lautstärke</string>
+	<string name="ui_adv_settings_usbvol_cat">USB-DAC Volume (ALSA, ROOT required)</string>
+	<string name="ui_adv_settings_usbvol_enable_title">Enable USB-DAC volume adjust</string>
+	<string name="ui_adv_settings_usbvol_enable_text">Ajust USB-DAC volume by HeadUnit\'s controls</string>
+    <string name="ui_adv_settings_usbvol_number_title">USB-DAC Card number in ALSA (N)</string>
+    <string name="ui_adv_settings_usbvol_number_text">Can be determined by terminal command: alsa_aplay -l</string>
+    <string name="ui_adv_settings_usbvol_name_title">Volume simple-control name</string>
+    <string name="ui_adv_settings_usbvol_name_text">Use terminal command (N-see prev.): alsa_amixer -cN scontrols</string>
     <string name="wdg_history_unknown_contact">Unbekannt</string>
     <string name="wdg_history_title">HeadUnit: Letze Anrufe</string>
     <string name="ui_service_title">RK3066 HeadUnit Dienst</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -39,7 +39,7 @@
 	<string name="ui_adv_settings_caller_cat">Звонки через Android</string>
 	<string name="ui_adv_settings_caller_enable_title">Звонить через Android</string>
 	<string name="ui_adv_settings_caller_enable_text">Начинать звонок через bluetooth по запросу приложения Android</string>
-	<string name="ui_adv_settings_caller_app_title">Приложение True Conctacts</string>
+	<string name="ui_adv_settings_caller_app_title">Приложение True Contacts</string>
 	<string name="ui_adv_settings_caller_app_text">Нажмите чтобы открыть рекомендованное приложение для записной книги и звонков</string>
 	<string name="ui_adv_settings_caller_api_title">Версия ПО управления звонками</string>
 	<string name="ui_adv_settings_caller_api_text">Выберите другое значение, если звонок из Android не работает</string>
@@ -61,6 +61,8 @@
 	<string name="ui_adv_settings_speedvol_speed_text">Рубеж скорости для увеличинения/уменьшения громкости</string>
 	<string name="ui_adv_settings_speedvol_level_title">Степень регулировки</string>
 	<string name="ui_adv_settings_speedvol_level_text">Насколько сильно громкость меняется на каждом шаге</string>
+	<string name="ui_adv_settings_speedvol_tol_title">Допуск скорости (инертность)</string>
+	<string name="ui_adv_settings_speedvol_tol_text">Громкость будет увеличена/уменьшена, если скорость выйдет за пределы установленного допуска (+/- от шага)</string>
 
 	<string name="ui_adv_settings_usbvol_cat">Громкость USB-DAC (нужны ALSA и ROOT)</string>
 	<string name="ui_adv_settings_usbvol_enable_title">Включить регулировку громкости на USB-DAC</string>
@@ -75,5 +77,11 @@
 
 	<string name="appcontrol_name_media_buttons">Эмуляция медиа-кнопок (гарнитуры)</string>
 	<string name="appcontrol_name_pcradio">PcRadio (требуется ROOT)</string>
-
+	<string name="cfg_theme_title">Интерфейс</string>
+	<string name="cfg_theme_summary">Измененить тему оформления</string>
+	<string name="cfg_design_title">Скин</string>
+	<string name="theme_item_default">Как у устройства</string>
+	<string name="theme_item_light">Светлый</string>
+	<string name="theme_item_dark">Темный</string>
+	<string name="theme_item_black">Черный</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -62,6 +62,14 @@
 	<string name="ui_adv_settings_speedvol_level_title">Степень регулировки</string>
 	<string name="ui_adv_settings_speedvol_level_text">Насколько сильно громкость меняется на каждом шаге</string>
 
+	<string name="ui_adv_settings_usbvol_cat">Громкость USB-DAC (нужны ALSA и ROOT)</string>
+	<string name="ui_adv_settings_usbvol_enable_title">Включить регулировку громкости на USB-DAC</string>
+	<string name="ui_adv_settings_usbvol_enable_text">Регулировка громкости USB-DAC штатными средствами ГУ</string>
+	<string name="ui_adv_settings_usbvol_number_title">Номер карты USB-DAC в ALSA (N)</string>
+	<string name="ui_adv_settings_usbvol_number_text">Определяется терминальной командой: alsa_aplay -l</string>
+	<string name="ui_adv_settings_usbvol_name_title">Имя симпл-контрола громкости</string>
+	<string name="ui_adv_settings_usbvol_name_text">Узнаётся терминальной командой (N-см.выше): alsa_amixer -cN scontrols</string>
+
 	<string name="wdg_history_title">Магнитола: звонки</string>
 	<string name="wdg_history_unknown_contact">Неизвестный</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,14 @@
 	<string name="ui_adv_settings_speedvol_tol_title">Speed tolerance</string>
 	<string name="ui_adv_settings_speedvol_tol_text">The volume will be in/decreased if the speed is higher/lower than the level +/- tolerance</string>
 
+	<string name="ui_adv_settings_usbvol_cat">USB-DAC Volume (ALSA, ROOT required)</string>
+	<string name="ui_adv_settings_usbvol_enable_title">Enable USB-DAC volume adjust</string>
+	<string name="ui_adv_settings_usbvol_enable_text">Ajust USB-DAC volume by HeadUnit\'s controls</string>
+    <string name="ui_adv_settings_usbvol_number_title">USB-DAC Card number in ALSA (N)</string>
+    <string name="ui_adv_settings_usbvol_number_text">Can be determined by terminal command: alsa_aplay -l</string>
+    <string name="ui_adv_settings_usbvol_name_title">Volume simple-control name</string>
+    <string name="ui_adv_settings_usbvol_name_text">Use terminal command (N-see prev.): alsa_amixer -cN scontrols</string>
+
 	<string name="wdg_history_title">HeadUnit Call History</string>
 	<string name="wdg_history_unknown_contact">Unknown</string>
 

--- a/app/src/main/res/xml/pref.xml
+++ b/app/src/main/res/xml/pref.xml
@@ -168,6 +168,31 @@
 			android:title="@string/ui_adv_settings_speedvol_tol_title" >
 		</EditTextPreference>
 	</PreferenceCategory>
+	<PreferenceCategory
+		android:key="usbvol"
+		android:summary=""
+		android:title="@string/ui_adv_settings_usbvol_cat" >
+		<CheckBoxPreference
+			android:defaultValue="false"
+			android:key="usbvol.enable"
+			android:summary="@string/ui_adv_settings_usbvol_enable_text"
+			android:title="@string/ui_adv_settings_usbvol_enable_title" >
+		</CheckBoxPreference>
 
+		<EditTextPreference
+			android:defaultValue="2"
+			android:dependency="usbvol.enable"
+			android:key="usbvol.number"
+			android:summary="@string/ui_adv_settings_usbvol_enable_text"
+			android:title="@string/ui_adv_settings_usbvol_number_title" >
+		</EditTextPreference>
+		<EditTextPreference
+			android:defaultValue="PCM"
+			android:dependency="usbvol.enable"
+			android:key="usbvol.name"
+			android:summary="@string/ui_adv_settings_usbvol_name_text"
+			android:title="@string/ui_adv_settings_usbvol_name_title" >
+		</EditTextPreference>
+	</PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
Added USB-DAC Volume adjustment support within Alsamixer commands synchronously to HU volume (can be switched on/off in Settings).
Write me (aluver) any questions about USB-Audio by PM on forum.xda-developers.com or http://4pda.ru/forum
Added Poweramp API function "Next In Cat", "Prev In Cat" to switch Albums or Folders by steering wheel controls (up/down arrows).
